### PR TITLE
Scope updates for the admin application

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -67,14 +67,12 @@ Resource list and detail views will display all native properties on a resource 
 ```bash
 VITE_APP_ORDERCLOUD_BASE_API_URL="https://sandboxapi.ordercloud.io"
 VITE_APP_ORDERCLOUD_CLIENT_ID="********-****-****-****-************"
-VITE_APP_ORDERCLOUD_SCOPE="OrderAdmin ProductAdmin CatalogAdmin AdminUserAdmin AdminUserGroupAdmin SupplierAdmin BuyerAdmin"
 VITE_APP_NAME="OrderCloud Admin Application"
 ```
 | Variable                            | Description                                                                                                       |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `VITE_APP_ORDERCLOUD_BASE_API_URL`  | Base OrderCloud API URL                                          |
 | `VITE_APP_ORDERCLOUD_CLIENT_ID`     | Admin Client ID                                                                                                   |
-| `VITE_APP_ORDERCLOUD_SCOPE`         | The ID for your OrderCloud Marketplace                                                                            |
 | `VITE_APP_NAME`                     | Name of the application title                                                                                     |
 
 2. Run Vite in development mode

--- a/apps/admin/src/constants/constants.ts
+++ b/apps/admin/src/constants/constants.ts
@@ -1,15 +1,9 @@
-import { ApiRole } from 'ordercloud-javascript-sdk'
 
 //Basic auth configuration
 const APP_NAME = import.meta.env.VITE_APP_NAME || 'Application Name'
 const BASE_API_URL =
   import.meta.env.VITE_APP_ORDERCLOUD_BASE_API_URL || 'https://api.ordercloud.io/v1'
 const CLIENT_ID = import.meta.env.VITE_APP_ORDERCLOUD_CLIENT_ID
-const SCOPE_STRING = import.meta.env.VITE_APP_ORDERCLOUD_SCOPE
-const CUSTOM_SCOPE_STRING = import.meta.env.VITE_APP_ORDERCLOUD_CUSTOM_SCOPE
-
-const SCOPE: ApiRole[] = SCOPE_STRING?.length ? (SCOPE_STRING.split(',') as ApiRole[]) : []
-const CUSTOM_SCOPE: string[] = CUSTOM_SCOPE_STRING?.length ? CUSTOM_SCOPE_STRING.split(',') : []
 
 //Anonymous auth configuration
 const ALLOW_ANONYMOUS_STRING = import.meta.env.VITE_APP_ORDERCLOUD_ALLOW_ANONYMOUS
@@ -25,8 +19,6 @@ export {
   APP_NAME,
   BASE_API_URL,
   CLIENT_ID,
-  SCOPE,
-  CUSTOM_SCOPE,
   ALLOW_ANONYMOUS,
   THEME_COLOR_PRIMARY,
   THEME_COLOR_SECONDARY,

--- a/apps/admin/src/providers/AppProvider.tsx
+++ b/apps/admin/src/providers/AppProvider.tsx
@@ -5,8 +5,6 @@ import {
   ALLOW_ANONYMOUS,
   BASE_API_URL,
   CLIENT_ID,
-  CUSTOM_SCOPE,
-  SCOPE,
 } from '../constants/constants'
 import { useToast } from '@chakra-ui/react'
 import { OrderCloudError } from 'ordercloud-javascript-sdk'
@@ -42,8 +40,8 @@ const AppProvider: FC = () => {
     <OrderCloudProvider
       baseApiUrl={BASE_API_URL}
       clientId={CLIENT_ID}
-      scope={SCOPE}
-      customScope={CUSTOM_SCOPE}
+      scope={[]}
+      customScope={[]}
       allowAnonymous={ALLOW_ANONYMOUS}
       defaultErrorHandler={defaultErrorHandler}
       xpSchemas={schemaObject}

--- a/apps/admin/src/vite-env.d.ts
+++ b/apps/admin/src/vite-env.d.ts
@@ -5,8 +5,6 @@ interface ImportMetaEnv {
   readonly VITE_APP_CONFIG_BASE?: string
   readonly VITE_APP_ORDERCLOUD_BASE_API_URL?: string
   readonly VITE_APP_ORDERCLOUD_CLIENT_ID: string
-  readonly VITE_APP_ORDERCLOUD_SCOPE?: string
-  readonly VITE_APP_ORDERCLOUD_CUSTOM_SCOPE?: string
   readonly VITE_APP_ORDERCLOUD_ALLOW_ANONYMOUS?: string
 
   VITE_APP_PUBLIC_THEME_COLOR_PRIMARY?: string

--- a/infrastructure/Helpers/WriteEnvVariables.cs
+++ b/infrastructure/Helpers/WriteEnvVariables.cs
@@ -70,7 +70,7 @@ namespace OC_Accelerator.Helpers
                 new()
                 {
                     name = "VITE_APP_ORDERCLOUD_CUSTOM_SCOPE",
-                    value = appType == ApplicationType.Storefront ? _appSettings.ocStorefrontCustomScope : _appSettings.ocAdminCustomScope
+                    value = appType == ApplicationType.Storefront ? _appSettings.ocStorefrontCustomScope : string.Empty
                 },
                 new()
                 {
@@ -91,7 +91,7 @@ namespace OC_Accelerator.Helpers
                 
                 return _appSettings.ocStorefrontScope;
             }
-            return _appSettings.ocAdminScope;
+            return string.Empty;
         }
     }
 }

--- a/infrastructure/appSettings.example.json
+++ b/infrastructure/appSettings.example.json
@@ -14,7 +14,7 @@
   "ocStorefrontCustomScope": null, // optional. Space delimited list of custom roles
   "ocStorefrontAllowAnon": true, // determines whether or not to allow anonymous shopping on the storefront application
   "ocAdminClientId": "", // optional. If not provided, one is created for you
-  "ocAdminScope": "OrderAdmin ProductAdmin CatalogAdmin AdminUserAdmin AdminUserGroupAdmin SupplierAdmin BuyerAdmin ShipmentAdmin PriceScheduleAdmin BundleAdmin PromotionAdmin", // optional. Space delimited list of roles
+  "ocAdminScope": "AdminAddressAdmin AdminUserAdmin AdminUserGroupAdmin ApprovalRuleAdmin BundleAdmin BuyerAdmin CatalogAdmin CategoryAdmin CostCenterAdmin CreditCardAdmin LocaleAdmin OrderAdmin PriceScheduleAdmin ProductAdmin PromotionAdmin SecurityProfileAdmin ShipmentAdmin SpendingAccountAdmin SupplierAddressAdmin SupplierAdmin SupplierUserAdmin SupplierUserGroupAdmin UserGroupAdmin", // optional. Space delimited list of roles
   "ocAdminCustomScope": null, // optional. Space delimited list of custom roles
   // IGNORE FOR NOW
   // Azure DevOps Settings


### PR DESCRIPTION
Resolves #71 

Update the `ocAdminScope` in `appSettings.example.json` to reflect the most recent additions to admin application resource management.  These roles will be used to populate the admin security profile (if creating) during the seeding process.

The scope variables for the admin app are causing confusion in development when a user has certain roles assigned, but those roles are missing from the user's  `.env.local` file.  Remove the scope variables from the admin constants file so that the login request is sent with an empty scope.