### PR TITLE
Limit storage sku options by standard/premium tiers

### DIFF
--- a/infrastructure/Helpers/AzurePlanOptions.cs
+++ b/infrastructure/Helpers/AzurePlanOptions.cs
@@ -8,19 +8,29 @@ namespace OC_Accelerator.Helpers
 {
     public class AzurePlanOptions
     {
-        public List<string> GetAzureStorageSkuValues()
+        public List<string> GetAzureStorageSkuValues(string planSku)
         {
-            return new List<string>
+            switch (planSku)
             {
-                "Premium_LRS",
-                "Premium_ZRS",
-                "Standard_GRS",
-                "Standard_GZRS",
-                "Standard_LRS",
-                "Standard_RAGRS",
-                "Standard_RAGZRS",
-                "Standard_ZRS",
-            };
+                case "B1":
+                case "B2":
+                case "B3":
+                    return new List<string>
+                    {
+                        "Standard_GRS",
+                        "Standard_GZRS",
+                        "Standard_LRS",
+                        "Standard_RAGRS",
+                        "Standard_RAGZRS",
+                        "Standard_ZRS",
+                    };
+                default:
+                    return new List<string>
+                    {
+                        "Premium_LRS",
+                        "Premium_ZRS",
+                    };
+            }
         }
 
         public List<string> GetAzureStorageKindValues(string storageSku)
@@ -35,7 +45,7 @@ namespace OC_Accelerator.Helpers
             return list;
         }
 
-        public List<string> GetAzureAppPlanSkuValues() // TODO: validate these
+        public List<string> GetAzureAppPlanSkuValues() 
         {
             return new List<string>
             {
@@ -44,7 +54,7 @@ namespace OC_Accelerator.Helpers
                 "B3",
                 "P0v3",
                 "P1v3",
-                "P1v2", // is this one valid?
+                "P1v2", 
                 "P1mv3",
                 "P2v3",
                 "P2mv3",

--- a/infrastructure/Services/AzureResourceService.cs
+++ b/infrastructure/Services/AzureResourceService.cs
@@ -63,7 +63,7 @@ public class AzureResourceService
         do
         {
             appPlanSku = Prompt.Select("Select the desired SKU for your Azure App Service Plan. Please see https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans for more information", _azPlanOptions.GetAzureAppPlanSkuValues());
-            storageSku = Prompt.Select("Select the desired SKU for your Azure Storage Account (required to create an Azure Function). Please see https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy for more information", _azPlanOptions.GetAzureStorageSkuValues());
+            storageSku = Prompt.Select("Select the desired SKU for your Azure Storage Account (required to create an Azure Function). Please see https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy for more information", _azPlanOptions.GetAzureStorageSkuValues(appPlanSku));
             storageType =
                 Prompt.Select(
                     "Select the desired storage type for your Azure Storage Account (required to create an Azure Function). Please see https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#types-of-storage-accounts for more information",


### PR DESCRIPTION
Resolves [#77](https://github.com/ordercloud-api/oc-accelerator/issues/77)

Limit premium tiers (P0v3, P1v3, P1v2, and above) to Premium storage options (Premium_LRS and Premium_ZRS)

Limit standard tiers (B1,B2,B3) to Standard storage options (Standard_LRS, Standard_GRS, Standard_GZRS, Standard_RAGRS, Standard_RAGZRS, and Standard_ZRS)