### PR TITLE
fix: remove deprecated Azure GPv1 storage

### DIFF
--- a/OC-Accelerator.Tests/UnitTest1.cs
+++ b/OC-Accelerator.Tests/UnitTest1.cs
@@ -16,18 +16,20 @@ namespace OC_Accelerator.Tests
         {
             var azPlanOpts = new AzurePlanOptions();
             var storageKinds = azPlanOpts.GetAzureStorageKindValues("Standard_LRS");
-            foreach (var expectedStorageKind in new List<string> { "BlobStorage", "Storage", "StorageV2" })
+            foreach (var expectedStorageKind in new List<string> { "BlobStorage", "StorageV2" })
             {
                 Assert.Contains(expectedStorageKind, storageKinds);
             }
+            Assert.False(storageKinds.Contains("Storage"));
             Assert.False(storageKinds.Contains("FileStorage"));
             Assert.False(storageKinds.Contains("BlockBlobStorage"));
 
             storageKinds = azPlanOpts.GetAzureStorageKindValues("Standard_GZRS");
-            foreach (var expectedStorageKind in new List<string> { "Storage", "StorageV2" })
+            foreach (var expectedStorageKind in new List<string> { "StorageV2" })
             {
                 Assert.Contains(expectedStorageKind, storageKinds);
             }
+            Assert.False(storageKinds.Contains("Storage"));
             Assert.False(storageKinds.Contains("FileStorage"));
             Assert.False(storageKinds.Contains("BlockBlobStorage"));
             Assert.False(storageKinds.Contains("BlobStorage"));

--- a/apps/api/Accelerator.Functions/Properties/ServiceDependencies/accelerator-functions - Zip Deploy/profile.arm.json
+++ b/apps/api/Accelerator.Functions/Properties/ServiceDependencies/accelerator-functions - Zip Deploy/profile.arm.json
@@ -150,7 +150,7 @@
               "sku": {
                 "name": "Standard_LRS"
               },
-              "kind": "Storage"
+              "kind": "StorageV2"
             },
             {
               "location": "[parameters('resourceGroupLocation')]",

--- a/apps/api/Accelerator.Functions/Properties/ServiceDependencies/accelerator-functions - Zip Deploy/storage1.arm.json
+++ b/apps/api/Accelerator.Functions/Properties/ServiceDependencies/accelerator-functions - Zip Deploy/storage1.arm.json
@@ -53,7 +53,7 @@
                 "name": "Standard_LRS",
                 "tier": "Standard"
               },
-              "kind": "Storage",
+              "kind": "StorageV2",
               "name": "sandboxdja232",
               "type": "Microsoft.Storage/storageAccounts",
               "location": "[parameters('resourceLocation')]",

--- a/infrastructure/Helpers/AzurePlanOptions.cs
+++ b/infrastructure/Helpers/AzurePlanOptions.cs
@@ -36,7 +36,7 @@ namespace OC_Accelerator.Helpers
         public List<string> GetAzureStorageKindValues(string storageSku)
         {
             // https://learn.microsoft.com/en-us/rest/api/storagerp/srp_sku_types
-            var list = new List<string> { "Storage", "StorageV2" };
+            var list = new List<string> { "StorageV2" };
             if (new List<string> { "Standard_LRS", "Standard_GRS", "Standard_RAGRS" }.Contains(storageSku))
                 list.Add("BlobStorage");
             else if (storageSku == "Premium_LRS")


### PR DESCRIPTION
## Summary
- remove the deprecated GPv1 `Storage` kind from Azure provisioning choices
- update checked-in Function service dependency templates to `StorageV2`
- verify the legacy kind is not returned by the storage-kind tests

## Validation
- `dotnet test infrastructure/OC-Accelerator.sln --configuration Release`
- `dotnet build apps/api/Accelerator.Api.sln --configuration Release`